### PR TITLE
Add server-side balance config options via MidnightLib

### DIFF
--- a/src/main/java/moriyashiine/nycto/client/ModConfig.java
+++ b/src/main/java/moriyashiine/nycto/client/ModConfig.java
@@ -10,4 +10,28 @@ public class ModConfig extends MidnightConfig {
 	public static boolean vampireChargeJump = true;
 	@Entry(category = "client")
 	public static boolean vampireStepHeight = true;
+
+	// Hunter balance
+	@Entry(category = "server", min = 1, max = 20)
+	public static int hunterMaxHeat = 5;
+	@Entry(category = "server", min = 0, max = 20)
+	public static int hunterMaxSpawns = 3;
+	@Entry(category = "server")
+	public static boolean weaponsBypassBloodVeil = true;
+	@Entry(category = "server")
+	public static boolean weaponsHaltRegeneration = true;
+
+	// Sun balance
+	@Entry(category = "server")
+	public static boolean sunDamageEnabled = true;
+	@Entry(category = "server")
+	public static boolean sunBypassesBloodVeil = true;
+	@Entry(category = "server")
+	public static boolean sunHaltsRegeneration = true;
+
+	// Fire balance
+	@Entry(category = "server")
+	public static boolean fireBypassesBloodVeil = true;
+	@Entry(category = "server")
+	public static boolean fireHaltsRegeneration = true;
 }

--- a/src/main/java/moriyashiine/nycto/common/component/entity/HunterHeatComponent.java
+++ b/src/main/java/moriyashiine/nycto/common/component/entity/HunterHeatComponent.java
@@ -74,8 +74,10 @@ public class HunterHeatComponent implements ServerTickingComponent {
 	}
 
 	public void increaseHeat() {
-		if (heatLevel + 1 >= MAXIMUM_HEAT) {
-			if (timesSpawned < MAXIMUM_SPAWNS) {
+		int maxHeat = moriyashiine.nycto.client.ModConfig.hunterMaxHeat;
+		int maxSpawns = moriyashiine.nycto.client.ModConfig.hunterMaxSpawns;
+		if (heatLevel + 1 >= maxHeat) {
+			if (timesSpawned < maxSpawns) {
 				if (HunterContractItem.spawnHunter(obj.getEntityWorld(), obj, NyctoAPI.isVampire(obj) ? HunterEntity.HunterType.VAMPIRE : HunterEntity.HunterType.WEREWOLF, obj.getRandom().nextBetween(1, 3)).isAccepted()) {
 					heatLevel = decayTicks = 0;
 					timesSpawned++;

--- a/src/main/java/moriyashiine/nycto/common/component/entity/SunExposureComponent.java
+++ b/src/main/java/moriyashiine/nycto/common/component/entity/SunExposureComponent.java
@@ -53,7 +53,7 @@ public class SunExposureComponent implements AutoSyncedComponent, CommonTickingC
 			if (exposed) {
 				if (exposureTime < MAX_EXPOSURE_TIME) {
 					exposureTime = Math.min(MAX_EXPOSURE_TIME, exposureTime + getExposureTicks());
-				} else {
+				} else if (moriyashiine.nycto.client.ModConfig.sunDamageEnabled) {
 					obj.setOnFireFor(4);
 				}
 			} else if (exposureTime > 0) {

--- a/src/main/java/moriyashiine/nycto/common/util/NyctoUtil.java
+++ b/src/main/java/moriyashiine/nycto/common/util/NyctoUtil.java
@@ -8,7 +8,9 @@ import moriyashiine.nycto.api.power.ActivePower;
 import moriyashiine.nycto.api.power.FormChanger;
 import moriyashiine.nycto.api.power.PowerInstance;
 import moriyashiine.nycto.common.init.ModDamageTypes;
+import moriyashiine.nycto.common.init.ModGameRules;
 import moriyashiine.nycto.common.init.ModParticleTypes;
+import moriyashiine.nycto.client.ModConfig;
 import moriyashiine.nycto.common.init.ModStatusEffects;
 import moriyashiine.nycto.common.power.vampire.DarkFormPower;
 import moriyashiine.nycto.common.tag.ModDamageTypeTags;
@@ -28,6 +30,7 @@ import net.minecraft.entity.passive.WanderingTraderEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.item.Item;
+import net.minecraft.registry.tag.DamageTypeTags;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
@@ -35,6 +38,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.village.VillagerGossipType;
+import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 
 public class NyctoUtil {
@@ -50,10 +54,16 @@ public class NyctoUtil {
 				return true;
 			}
 		}
+		if (source.isIn(DamageTypeTags.IS_FIRE) && !ModConfig.fireBypassesBloodVeil) return false;
+		if (source.isOf(ModDamageTypes.SUN) && !ModConfig.sunBypassesBloodVeil) return false;
+		if (isVampireWeaknessItem(source) && !ModConfig.weaponsBypassBloodVeil) return false;
 		return source.isIn(ModDamageTypeTags.BYPASSES_BLOOD_VEIL) || isVampireWeaknessItem(source) || NyctoAPI.isBeastForm(source);
 	}
 
 	public static boolean haltsVampireRegeneration(DamageSource source) {
+		if (source.isIn(DamageTypeTags.IS_FIRE) && !ModConfig.fireHaltsRegeneration) return false;
+		if (source.isOf(ModDamageTypes.SUN) && !ModConfig.sunHaltsRegeneration) return false;
+		if (isVampireWeaknessItem(source) && !ModConfig.weaponsHaltRegeneration) return false;
 		return source.isIn(ModDamageTypeTags.HALTS_VAMPIRE_REGENERATION) || isVampireWeaknessItem(source);
 	}
 


### PR DESCRIPTION
This PR adds configurable balance options for vampires using MidnightLib, accessible via Mod Menu under a new "server" category.

### New config options

**Hunter balance:**
- `hunterMaxHeat` — how many actions before hunters spawn (default: 5)
- `hunterMaxSpawns` — how many hunter groups can spawn (default: 3)

**Sun balance:**
- `sunDamageEnabled` — whether the sun burns vampires (default: true)
- `sunBypassesBloodVeil` — whether sun damage bypasses the blood veil (default: true)
- `sunHaltsRegeneration` — whether sun damage blocks healing (default: true)

**Fire balance:**
- `fireBypassesBloodVeil` — whether fire damage bypasses the blood veil (default: true)
- `fireHaltsRegeneration` — whether fire damage blocks healing (default: true)

**Weapon balance:**
- `weaponsBypassBloodVeil` — whether vampire weakness items bypass the blood veil (default: true)
- `weaponsHaltRegeneration` — whether vampire weakness items block healing (default: true)

All options default to the original hardcoded behavior, so this is fully backwards compatible.